### PR TITLE
Add support for http header tokens

### DIFF
--- a/examples/simple_without_use_jwt_with_http_headers.rs
+++ b/examples/simple_without_use_jwt_with_http_headers.rs
@@ -1,0 +1,83 @@
+use actix_jwt_auth_middleware::{AuthResult, Authority, CookieSigner, FromRequest, AuthenticationService};
+use actix_web::{
+    get,
+    web::{self, Data},
+    App, HttpResponse, HttpServer, Responder,
+};
+use exonum_crypto::KeyPair;
+use jwt_compact::alg::Ed25519;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, FromRequest)]
+struct User {
+    id: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Tokens {
+    pub access_token: String,
+    pub refresh_token: String,
+}
+
+
+#[actix_web::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let key_pair = KeyPair::random();
+
+    let cookie_signer = CookieSigner::new()
+        .signing_key(key_pair.secret_key().clone())
+        .algorithm(Ed25519)
+        .build()?;
+
+    let authority = Authority::<User, _, _, _>::new()
+        .refresh_authorizer(|| async move { Ok(()) })
+        .cookie_signer(Some(cookie_signer.clone()))
+        .verifying_key(key_pair.public_key().clone())
+        .enable_header_tokens(true)
+        .build()?;
+
+    Ok(HttpServer::new(move || {
+        App::new()
+            .service(login)
+            // we inject the cookie_signer here into the application state 
+            // in oder to later create a signer jwt cookie 
+            // from within the login function
+            .app_data(Data::new(cookie_signer.clone()))
+            .service(
+                // we need this scope so we can exclude the login service
+                // from being wrapped by the jwt middleware
+                web::scope("")
+                    .service(hello)
+                    .wrap(
+                        AuthenticationService::new(authority.clone())
+                    )
+                )
+    })
+    .bind(("127.0.0.1", 8080))?
+    .run()
+    .await?)
+}
+
+#[get("/login")]
+async fn login(cookie_signer: web::Data<CookieSigner<User, Ed25519>>) -> AuthResult<HttpResponse> {
+    let user = User { id: 1 };
+
+    let access_token = cookie_signer.create_access_token_cookie(&user)?;
+    let refresh_token = cookie_signer.create_refresh_token_cookie(&user)?;
+
+    let access_token_value = access_token.value();
+    let refresh_token_value = refresh_token.value();
+
+    Ok(HttpResponse::Ok()
+        .json(Tokens{access_token: access_token_value.to_string(), refresh_token: refresh_token_value.to_string()}))
+}
+
+#[get("/hello")]
+// what ever claim type was wrapped, can be extracted from within the wrapped services.
+//
+// Note:    your claim type has to implement the FromRequest trait 
+//          or you have to annotated with the FromRequest derive macro provided in this crate.  
+//
+async fn hello(user: User) -> impl Responder {
+    format!("Hello there, i see your user id is {}.", user.id)
+}

--- a/tests/test_tokens.rs
+++ b/tests/test_tokens.rs
@@ -45,6 +45,31 @@ async fn valid_access_token() {
 }
 
 #[actix_web::test]
+async fn valid_access_token_header() {
+    let authority: Authority<TestClaims, _, _, _> = Authority::new()
+        .algorithm(Ed25519)
+        .verifying_key(KEY_PAIR.public_key())
+        .time_options(*TIME_OPTIONS)
+        .refresh_authorizer(|| async { Ok(()) })
+        .enable_header_tokens(true)
+        .build()
+        .unwrap();
+
+    let cookie =  COOKIE_SIGNER
+        .create_access_token_cookie(&TestClaims {})
+        .unwrap();  
+
+    let req = TestRequest::default()
+        .insert_header((
+            cookie.name(),
+                cookie.value(),
+        ))
+        .to_srv_request();
+
+    assert!(authority.verify_service_request(req).await.is_ok())
+}
+
+#[actix_web::test]
 async fn valid_refresh_token() {
     let authority: Authority<TestClaims, _, _, _> = Authority::new()
         .verifying_key(KEY_PAIR.public_key())


### PR DESCRIPTION
Hello @michaelvanstraten !

I found myself digging more into your library, and, at first, I was surprised that I couldn't make it work with tools such as Postman or Thunder Client (for vscode) that are not dealing so well with cookies between queries. Moreover, when building a classical rest API, it's useful to be able to rely on something else than cookie.

To offer more auth scheme than cookie, I added support for http headers. 

Setting `Authority::enable_header_tokens` to `true` (default: `false`) as shown in `examples/simple_without_use_jwt_with_http_headers.rs` will check for auth tokens in http headers as a fallback when they are not present as a cookie.

I see several improvements that could be made:

1. Rename `CookieSigner` to `Signer` or something like this, as it signs more than cookie now.
2. Ability to deactivate `Cookie` auth (like we http header auth is by default) so we don't check for `Cookie` when we don't use them.
3. [This](https://github.com/michaelvanstraten/actix-jwt-auth-middleware/compare/master...MathieuNls:actix-jwt-auth-middleware:header_support?expand=1#diff-3e527969a75ec7e713e9635e1048fee53d716103a6e23788bc11a8b8f68f9fd0R188) is a bit suspicious but was required to make `valid_refresh_token` pass.

Let me know if this contribution interests you and if you want to move forward with supporting http header as an option.

Regards,
M.

