### PR TITLE
Fix "bearer" unstriped in authorization header

### DIFF
--- a/src/authority.rs
+++ b/src/authority.rs
@@ -344,8 +344,8 @@ where
     ) -> AuthResult<Token<Claims>> {
         match header_map.get(AUTHORIZATION).map(HeaderValue::to_str) {
             Some(Ok(header_value)) => {
-                let token_value = if header_value.strip_prefix("Bearer").is_some() {
-                    header_value.trim()
+                let token_value = if let Some(token_value) = header_value.strip_prefix("Bearer") {
+                    token_value.trim()
                 } else {
                     // to-do: better error handling
                     return Err(AuthError::NoToken);


### PR DESCRIPTION
I found an error when calling the `get_token_from_authorization_header function`: `TokenParse(InvalidBase64Encoding)`. 

The code seems to not correctly remove the "Bearer" prefix.

I tried modifying the code and tested my hypothesis in my project, and it seems resolved the issue.
