### PR TITLE
Set SameSite to Strict in auth cookies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "actix-jwt-auth-middleware"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "actix-jwt-auth-middleware-derive",
  "actix-state-guards",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["derive", "./."]
 
 [package]
 name = "actix-jwt-auth-middleware"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Michael van Straten"]
 repository = "https://github.com/michaelvanstraten/actix-jwt-auth-middleware"

--- a/src/token_signer.rs
+++ b/src/token_signer.rs
@@ -5,6 +5,7 @@ use std::marker::PhantomData;
 use std::time::Duration;
 
 use actix_web::cookie::Cookie;
+use actix_web::cookie::SameSite;
 use actix_web::http::header::HeaderValue;
 use chrono::TimeDelta;
 use derive_builder::Builder;
@@ -249,6 +250,7 @@ where
     ) -> AuthResult<Cookie<'static>> {
         let token = self.create_signed_token(claims, token_lifetime)?;
         Ok(Cookie::build(cookie_name.to_string(), token)
+            .same_site(SameSite::Strict)
             .secure(true)
             .finish())
     }


### PR DESCRIPTION
I think that, by default, we should set the [`SameSite` attribute](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) to `Strict`, protecting against CSRF attacks. Note that this is a breaking change.